### PR TITLE
Adds recursively joining lists inside of maps

### DIFF
--- a/_recursive-map-merge.scss
+++ b/_recursive-map-merge.scss
@@ -1,9 +1,13 @@
-@function recursive-map-merge($map1, $map2) {
+@function recursive-map-merge($map1, $map2, $config:() ) {
     @if ((type-of($map1) == map or type-of($map1) == list) and (type-of($map2) == map or type-of($map2) == list)) {
         $result: $map1;
         @each $key, $value in $map2 {
             @if (type-of(map-get($result, $key)) == map and type-of($value) == map) {
                 $result: map-merge($result, ($key: recursive-map-merge(map-get($result, $key), $value)));
+            }
+            @else if ( map-get($config, 'merge-lists') and type-of(map-get($result, $key)) == list and type-of($value) == list)
+            {
+                $result: map-merge($result, ($key: join(map-get($result, $key), $value)));
             }
             @else {
                 $result: map-merge($result, ($key: $value));


### PR DESCRIPTION
Re: Issue #4 

This still wouldn't work if given two lists, but it didn't before, and if you want that you can use `join()` anyway.

I guess if someone didn't know if they had two lists, or some nested maps, then they might struggle, but they'd have struggled before too.

I do think this is probably a dangerous change for any existing usages though, which might expect to overwrite lists, not merge them. I'm not sure how you want to handle that, either a version bump or we could make these into two functions...